### PR TITLE
Underscore separators

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/caarlos0/env"
 	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-elasticsearch/v8/typedapi/core/index"
 	"github.com/joho/godotenv"
 )
 
@@ -20,10 +19,10 @@ type ErrorHandlerFunc func(error)
 type Config struct {
 	Address string `env:"ES_LOG_ADDRESS"`
 	Index   string `env:"ES_LOG_INDEX"`
-	User string `env:"ES_LOG_USER"`
-	Pass string `env:"ES_LOG_PASS"`
+	User    string `env:"ES_LOG_USER"`
+	Pass    string `env:"ES_LOG_PASS"`
 
-	ESIndex      *index.Index
+	ESClient     *elasticsearch.TypedClient
 	MinLevel     slog.Level
 	ContextFuncs []ContextAttrFunc
 	ErrorHandler ErrorHandlerFunc
@@ -48,7 +47,7 @@ func (cfg *Config) ConnectEsLog() error {
 		)
 	}
 
-	cfg.ESIndex = es.Index(cfg.Index)
+	cfg.ESClient = es
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -17,10 +17,11 @@ type ContextAttrFunc func(context.Context) []slog.Attr
 type ErrorHandlerFunc func(error)
 
 type Config struct {
-	Address string `env:"ES_LOG_ADDRESS"`
-	Index   string `env:"ES_LOG_INDEX"`
-	User    string `env:"ES_LOG_USER"`
-	Pass    string `env:"ES_LOG_PASS"`
+	Address         string `env:"ES_LOG_ADDRESS"`
+	Index           string `env:"ES_LOG_INDEX"`
+	User            string `env:"ES_LOG_USER"`
+	Pass            string `env:"ES_LOG_PASS"`
+	IndexTimeFormat string `env:"ES_LOG_INDEX_TIME_FORMAT"`
 
 	ESClient     *elasticsearch.TypedClient
 	MinLevel     slog.Level

--- a/example_test.go
+++ b/example_test.go
@@ -30,7 +30,7 @@ func Example() {
 	}
 
 	// or use arleady established connection
-	slogEsCfg.ESIndex = slogelastic.AlreadyConnected()
+	slogEsCfg.ESClient = slogelastic.AlreadyConnected()
 
 	// finalize configuration and build slog.Handler
 	esHandler := slogEsCfg.NewElasticHandler()

--- a/handler.go
+++ b/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/elastic/go-elasticsearch/v8"
 )
@@ -79,7 +80,7 @@ func (cfg Config) NewElasticHandler() slog.Handler {
 
 	h := &Handler{
 		esClient:        cfg.ESClient,
-		esIndex:         cfg.Index,
+		esIndex:         strings.ToLower(cfg.Index),
 		contextFuncs:    cfg.ContextFuncs,
 		minLevel:        cfg.MinLevel,
 		errorHandler:    cfg.ErrorHandler,

--- a/handler.go
+++ b/handler.go
@@ -6,11 +6,12 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/elastic/go-elasticsearch/v8/typedapi/core/index"
+	"github.com/elastic/go-elasticsearch/v8"
 )
 
 type Handler struct {
-	esIndex      *index.Index
+	esClient     *elasticsearch.TypedClient
+	esIndex      string
 	minLevel     slog.Level
 	contextFuncs []ContextAttrFunc
 	groups       []string
@@ -54,7 +55,9 @@ func (h *Handler) Handle(ctx context.Context, rec slog.Record) error {
 
 	addAttributesToDocument(document, allAttrs, prefix)
 
-	if err := indexDocument(h.esIndex, document); err != nil {
+	indexName := fmt.Sprintf("%s-%s", h.esIndex, rec.Time.Format("2006-01-02"))
+
+	if err := indexDocument(h.esClient, indexName, document); err != nil {
 		h.errorHandler(err)
 	}
 
@@ -70,7 +73,8 @@ func (cfg Config) NewElasticHandler() slog.Handler {
 	}
 
 	h := &Handler{
-		esIndex:      cfg.ESIndex,
+		esClient:     cfg.ESClient,
+		esIndex:      cfg.Index,
 		contextFuncs: cfg.ContextFuncs,
 		minLevel:     cfg.MinLevel,
 		errorHandler: cfg.ErrorHandler,

--- a/handler.go
+++ b/handler.go
@@ -10,13 +10,14 @@ import (
 )
 
 type Handler struct {
-	esClient     *elasticsearch.TypedClient
-	esIndex      string
-	minLevel     slog.Level
-	contextFuncs []ContextAttrFunc
-	groups       []string
-	errorHandler func(error)
-	attrs        []slog.Attr
+	esClient        *elasticsearch.TypedClient
+	esIndex         string
+	minLevel        slog.Level
+	contextFuncs    []ContextAttrFunc
+	groups          []string
+	errorHandler    func(error)
+	attrs           []slog.Attr
+	IndexTimeFormat string
 }
 
 var _ slog.Handler = &Handler{}
@@ -55,7 +56,11 @@ func (h *Handler) Handle(ctx context.Context, rec slog.Record) error {
 
 	addAttributesToDocument(document, allAttrs, prefix)
 
-	indexName := fmt.Sprintf("%s-%s", h.esIndex, rec.Time.Format("2006-01-02"))
+	// check if indexTimeFormat is set
+	indexName := h.esIndex
+	if h.IndexTimeFormat != "" {
+		indexName = fmt.Sprintf("%s-%s", h.esIndex, rec.Time.Format(h.IndexTimeFormat))
+	}
 
 	if err := indexDocument(h.esClient, indexName, document); err != nil {
 		h.errorHandler(err)
@@ -73,11 +78,12 @@ func (cfg Config) NewElasticHandler() slog.Handler {
 	}
 
 	h := &Handler{
-		esClient:     cfg.ESClient,
-		esIndex:      cfg.Index,
-		contextFuncs: cfg.ContextFuncs,
-		minLevel:     cfg.MinLevel,
-		errorHandler: cfg.ErrorHandler,
+		esClient:        cfg.ESClient,
+		esIndex:         cfg.Index,
+		contextFuncs:    cfg.ContextFuncs,
+		minLevel:        cfg.MinLevel,
+		errorHandler:    cfg.ErrorHandler,
+		IndexTimeFormat: cfg.IndexTimeFormat,
 	}
 
 	return h

--- a/handler_helpers.go
+++ b/handler_helpers.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/elastic/go-elasticsearch/v8/typedapi/core/index"
+	"github.com/elastic/go-elasticsearch/v8"
 )
 
 // createBaseDocument creates the initial log document with basic record information
@@ -73,8 +73,10 @@ func addAttributesToDocument(document map[string]any, attrs []slog.Attr, prefix 
 }
 
 // indexDocument sends the document to Elasticsearch using the provided index client
-// and returns any error that occurs during indexing
-func indexDocument(esIndex *index.Index, document map[string]any) error {
-	_, err := esIndex.Document(document).Do(context.TODO())
+// and returns any error that occurs during indexing. If timestamp is provided,
+// it will be used to create a time-based index name.
+func indexDocument(esClient *elasticsearch.TypedClient, indexName string, document map[string]any) error {
+
+	_, err := esClient.Index(indexName).Document(document).Do(context.TODO())
 	return err
 }

--- a/handler_helpers.go
+++ b/handler_helpers.go
@@ -24,7 +24,7 @@ func buildPrefix(groups []string) string {
 	if len(groups) == 0 {
 		return ""
 	}
-	return strings.Join(groups, ".") + "."
+	return strings.Join(groups, "_") + "_"
 }
 
 // collectRecordAttributes extracts all attributes from the slog.Record
@@ -62,7 +62,7 @@ func addAttributesToDocument(document map[string]any, attrs []slog.Attr, prefix 
 			groupName := attr.Key
 			groupValues := attr.Value.Group()
 
-			addAttributesToDocument(document, groupValues, prefix+groupName+".")
+			addAttributesToDocument(document, groupValues, prefix+groupName+"_")
 		} else {
 			// Handle regular attributes
 			key := prefix + attr.Key

--- a/prepare_test.go
+++ b/prepare_test.go
@@ -9,14 +9,13 @@ import (
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-elasticsearch/v8/typedapi/core/index"
 )
 
-func AlreadyConnected() *index.Index {
+func AlreadyConnected() *elasticsearch.TypedClient {
 	client, _ := elasticsearch.NewTypedClient(elasticsearch.Config{
 		Transport: &TestRoundTripper{},
 	})
-	return client.Index("not-relevant")
+	return client
 }
 
 type TestRoundTripper struct{}


### PR DESCRIPTION
We have to use _ (underscore) instead of . (dot) because compatibility.